### PR TITLE
using process.env.VELOCITY as the check rather than debugOnly

### DIFF
--- a/google-fake.js
+++ b/google-fake.js
@@ -1,7 +1,8 @@
-HttpInterceptor = Package['xolvio:http-interceptor'].HttpInterceptor;
-HttpInterceptor.registerInterceptor('https://www.googleapis.com', Meteor.absoluteUrl('fake.www.googleapis.com'));
-HttpInterceptor.registerInterceptor('https://accounts.google.com', Meteor.absoluteUrl('fake.accounts.google.com'));
-
+if (process.env.VELOCITY){
+  HttpInterceptor = Package['xolvio:http-interceptor'].HttpInterceptor;
+  HttpInterceptor.registerInterceptor('https://www.googleapis.com', Meteor.absoluteUrl('fake.www.googleapis.com'));
+  HttpInterceptor.registerInterceptor('https://accounts.google.com', Meteor.absoluteUrl('fake.accounts.google.com'));
+}
 
 Router.route('fake.accounts.google.com/o/oauth2/auth', function () {
   var parameters = _fixIronRouterBug(this.request.query);

--- a/oauth-fake-client.js
+++ b/oauth-fake-client.js
@@ -1,17 +1,18 @@
 // intercept the URL out to the oauth service
-var _launchLogin = Package.oauth.OAuth.launchLogin;
-Package.oauth.OAuth.launchLogin = function (options) {
+if (Meteor.settings.public.test){
+  var _launchLogin = Package.oauth.OAuth.launchLogin;
+  Package.oauth.OAuth.launchLogin = function (options) {
 
-  var args = arguments;
+    var args = arguments;
 
-  // Make sure a fake options implementation exists for the login service
-  if (_getFakeOptionsFor[options.loginService]) {
-    args = [_getFakeOptionsFor[options.loginService](options)];
-  }
+    // Make sure a fake options implementation exists for the login service
+    if (_getFakeOptionsFor[options.loginService]) {
+      args = [_getFakeOptionsFor[options.loginService](options)];
+    }
 
-  return _launchLogin.apply(this, args);
-};
-
+    return _launchLogin.apply(this, args);
+  };
+}
 
 var _getFakeOptionsFor = {
   'google': function (options) {

--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.describe({
 
 Package.on_use(function (api) {
   api.use('google@1.1.2', ['client', 'server']);
-  api.use(['xolvio:http-interceptor@0.4.0'], ['server']);
+  api.use(['xolvio:http-interceptor@0.5.1'], ['server']);
   api.use(['iron:router@1.0.6'], ['server']);
   api.add_files('oauth-fake-client.js', 'client');
   api.add_files('google-fake.js', ['server']);


### PR DESCRIPTION
Ideally the fake should only run in case of test. But in the current configuration it also runs in development scenarios where debugOnly is still true. Would it not be better to base it on the basis of VELOCITY 
